### PR TITLE
Fix _processSingleAddRemoveBuffer function

### DIFF
--- a/src/layersupport.js
+++ b/src/layersupport.js
@@ -244,6 +244,7 @@ L.MarkerClusterGroup.LayerSupport = L.MarkerClusterGroup.extend({
 				layersBuffer.push(currentOperation.layer);
 			} else {
 				this[currentOperationType](layersBuffer);
+				currentOperationType = currentOperation.type;
 				layersBuffer = [currentOperation.layer];
 			}
 		}


### PR DESCRIPTION
The function always executed all operations in the buffer with the operation type of the first operation. This leads to missing markers or duplicated markers when the buffer contains operations with different types.